### PR TITLE
Fix deprecated node12 issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update release files
         run: cd src/ontology/ && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' GITHUB_ACTION=true prepare_release_fast
       - name: Run release
-        uses: softprops/action-gh-release@v1
+        uses: gaoDean/action-gh-release@v1
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
This is a temporary fix for

* [deploy](https://github.com/mgijax/mammalian-phenotype-ontology/actions/runs/3266823799)

>Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, softprops/action-gh-release, actions/checkout

* It is using a fork of `softprops/action-gh-release` with a fix.
* Revert this temporary change when it gets fixed in `softprops`.