### PR TITLE
Fix version so that it refers to specific commit hash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update release files
         run: cd src/ontology/ && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' GITHUB_ACTION=true prepare_release_fast
       - name: Run release
-        uses: gaoDean/action-gh-release@v1
+        uses: gaoDean/action-gh-release@6b61bb5648ddc1241deb73ea6b72c3a1e1f9e445
         with:
           generate_release_notes: true
           draft: true


### PR DESCRIPTION
Second round of fixes.
Fix the errors related to deprecated node12.
This is related to #3674